### PR TITLE
Add support for CSS nested selectors in UI map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,11 @@ A Clojure library designed to help with writing integration tests using
 ;; Functions (by-...) are so-called "selectors" - they return a map
 ;; in a form accepted by (taxi/find-element).
 (def ui {:search-btn (by-ng-click "search()")
-         :form [(by-class-name ".search-form")
-                :name [:_ (by-ng-model "query.name")]
-                :age  [:_ (by-ng-model "query.name")]]
-         :results [(by-role "result-table")
-                   :all-rows (by-class-name ".row")]})
-
+         :form       {:self (by-class-name ".search-form")
+                      :name (by-ng-model "query.name")
+                      :age  (by-ng-model "query.name")}
+         :results    {:self (by-role "result-table")
+                      :all-rows (by-class-name ".row")}})
 
 (deftest user-interface
   ;; Register UI map
@@ -87,14 +86,19 @@ For example:
 (def ui {:submit-btn (by-exact-text "Submit")
          :cancel-btn (by-exact-text "Cancel")
          :even-rows  (by-xpath "//tr[position() mod 2 = 0]")
-         :menu       [(by-role "user-menu")
+         :menu       {:self            (by-role "user-menu")
                       :change-password (by-ng-click "changePassword()")
-                      :log-out         (by-ng-click "logOut()")]})
+                      :log-out         (by-ng-click "logOut()")}})
 
 (set-ui-spec! ui)
 ```
 
-Top level UI elements can have children (one level nesting is currently supported)
+You can target decendants of top level UI elements (one level supported).
+
+```
+(def ui {:parent {:self      (...)
+                  :decendant (..)}})
+```
 - see the `:menu` element in an example above.
 
 #### set-ui-spec!
@@ -107,17 +111,24 @@ their label (which is a key in a map).
 
 #### $
 
-`($ :submit-btn)`
+```clojure
+;; Find element
+`($ :menu)`
 
-`($ :menu :change-password)`
+;; Same as above (find element)
+`($ :menu :self)`
 
+;; Find decendant to :menu
+`($ :menu :log-out)`
+
+;; Find by x-path
 `($ (by-xpath "//*[contains(@data-x, 'something')]"))`
+```
 
 Used to find one element matching the query. The preferred way of using this method
 is to pass the key(s) specifying element in the UI map.
 
 Alternatively, you can use a selector directly.
-
 
 #### $$
 
@@ -129,9 +140,8 @@ Same as `$`, but returns not one, but all matching elements.
 
 ### Simple selectors
 
-Selectors are simple functions that return either a string or a same map as
-accepted by `taxi/find-element`. If a string is returned, it is assumed to be
-an XPath expression.
+Selectors are simple functions that return the same map as
+accepted by `taxi/find-element`.
 
 taxi-toolkit comes with a basic set of selectors, as well as set of selectors
 useful in Angular application testing. You can easily write your own. Don't
@@ -345,7 +355,6 @@ Asserts that element contains the given text.
 (assert-ui {:submit-btn (text= "Submit")})
 ```
 
-
 ### Waiters
 
 When an action is performed, you often want to assert on the UI after it becomes
@@ -433,7 +442,7 @@ Works like `taxi/text` for elements such as `<div>` or `<p>`, and like
 
 #### classes
 
-`(clases ($ :menu :log-out))`
+`(classes ($ :menu :log-out))`
 
 #### click-not-clickable
 

--- a/src/io/aviso/taxi_toolkit/selectors/general.clj
+++ b/src/io/aviso/taxi_toolkit/selectors/general.clj
@@ -6,7 +6,7 @@
   Use either (by-xpath \"...\") to find one element,
   or (by-xpath :all \"...\") to find all."
   [& xs]
-  (apply str xs))
+  {:xpath (apply str xs)})
 
 (defn by-css
   "Find element by CSS selector"

--- a/src/io/aviso/taxi_toolkit/ui.clj
+++ b/src/io/aviso/taxi_toolkit/ui.clj
@@ -14,7 +14,7 @@
 
 (defn set-ui-spec!
   [& xs]
-  (reset! ui-maps (apply merge (map gen-ui-map xs))))
+  (reset! ui-maps (apply merge xs)))
 
 (defn $
   "Find one element"

--- a/src/io/aviso/taxi_toolkit/ui_map.clj
+++ b/src/io/aviso/taxi_toolkit/ui_map.clj
@@ -1,70 +1,13 @@
 (ns io.aviso.taxi-toolkit.ui-map
   "Generating UI maps for easy DOM access."
-  (:require [clj-webdriver.taxi :refer [find-element find-elements]]
+  (:require [clj-webdriver.taxi :refer [find-element find-elements find-element-under find-elements-under]]
             [io.aviso.taxi-toolkit.utils :refer :all]))
 
-
-(defn- resolve-parent-reference
-  "If child element refers to the parent element using :_ keyword,
-  it needs to be resolved so the resulting XPath expression is valid.
-
-  For instance [:child [:_ \"/..\"]] with parent \"//div[@class='abc']\"
-  would resolve to: [:child [\"//div[@class='abc']/..\"]]"
-  [parent [child-name child-spec]]
-  (let [child-spec-resolved (map #(if (= :_ %) parent %) child-spec)]
-    [child-name (apply str child-spec-resolved)]))
-
-(defn- gen-ui-element-spec
-  "Accepts a vector where first item describes the parent element,
-  and rest consist of tuples: label and spec of child elements.
-
-  This function rewrites this into a map, and resolves all parent
-  references ':_'.
-
-  For instance:
-
-      [\"//div\"
-       :child1 [:_ \"/h1\"]
-       :child2 [:_ \"/h2\"]]
-
-  Would be transformed into:
-
-      {:self \"//div\"
-       :child1 \"//div/h1\"
-       :child2 \"//div/h2\"}"
-  [[el-itself & children]]
-  (let [unresolved (apply hash-map children)
-        resolved (map (partial resolve-parent-reference el-itself) unresolved)]
-    (assoc (into {} resolved) :self el-itself)))
-
-(defn- gen-ui-element
-  "Transforms tuples from the UI map into the format used
-  by functions such as (find-one) and (find-all)."
-  [[label spec]]
-  (if (vector? spec)
-    [label (gen-ui-element-spec spec)]
-    [label {:self spec}]))
-
-(defn gen-ui-map
-  "Builds UI map out of user supplied map."
-  [m]
-  (into {} (map gen-ui-element m)))
-
-(defn- xpath-or-css
-  "Given a query, returns it in a form accepted by
-  (clj.webdriver.taxi/find-element) - as a map with
-  key either :xpath (default) or :css. If a string
-  is supplied, assumes it's a xpath selector."
-  [query]
-  (cond
-    (:css query) query
-    (:xpath query) query
-    :else {:xpath query}))
 
 (defn resolve-element-path
   "Finds element in a UI map."
   [m path-spec]
-  (if-let [el (get-in m path-spec)]
+  (if-let [el (get-in m (if (sequential? path-spec) path-spec (list path-spec)))]
     (if (:self el)
       (:self el)
       el)
@@ -78,22 +21,34 @@
   - (find-with-f \"//div\") - maps to (taxi/find-element(s) {:xpath \"//div\"})
   - (find-with-f ui-map \"//div\") - same as above
   - (find-with-f ui-map :el1 :el2) - will look up selector for [:el1 :el2] in UI map
-                                     and use it as a parameter for taxi/find-element(s)."
-  ([f query]
-   (f (xpath-or-css query)))
-  ([f ui & el-path]
-   (if (and (= 1 (count el-path))
-            (string? (first el-path)))
-     (find-with-f f (first el-path))
-     (f (xpath-or-css (resolve-element-path ui el-path))))))
+  and use it as a parameter for taxi/find-element(s)."
+  [f-one f-nested ui & el-spec]
+  (if (map? (first el-spec))
+    ;; Allows user to call function without looking the element
+    ;; reference up in the UI map:
+    ;;   (find-with-f ... ... ... {:xpath "..."})
+    ;;   (find-widt-f ... ... ... {:css "..."})
+    (f-one (first el-spec))
+
+    ;; Allows user to call function by looking the element
+    ;; reference up in the UI map:
+    ;;   (find-with-f ... ... ui-map :el-name)
+    ;;   (find-with-f ... ... ui-map :el-name :child)
+    (let [parent-spec (first el-spec)
+          child-spec (second el-spec)]
+      (if (or (= nil child-spec)
+              (= :self child-spec))
+        (f-one (resolve-element-path ui el-spec))
+        (f-nested (find-element (resolve-element-path ui parent-spec))
+                  (resolve-element-path ui el-spec))))))
 
 (defn find-one
   "Find one element matching selector. See (find-with-f)."
   [& args]
-  (apply (partial find-with-f find-element) args))
+  (apply (partial find-with-f find-element find-element-under) args))
 
 (defn find-all
   "Find all element matching selector. See (find-with-f)."
   [& args]
-  (apply (partial find-with-f find-elements) args))
+  (apply (partial find-with-f find-elements find-elements-under) args))
 


### PR DESCRIPTION
Provides a support for:

```
(def ui {:heading-xpath {:self (by-xpath "//*[contains(@class, 'panel-heading')]")
                         :child (by-xpath "//a[contains(@class, 'btn')]")}
         :heading-css   {:self (by-css ".panel-heading")
                         :child (by-css "a.btn")}
         :heading-xpath-css   {:self (by-xpath "//*[contains(@class, 'panel-heading')]")
                               :child (by-css "a.btn")}
         :heading-css-xpath   {:self (by-css ".panel-heading")
                               :child (by-xpath "//a[contains(@class, 'btn')]")}})

($ :heading-xpath)
($ :heading-xpath :self)
($ :heading-xpath :child)

(and so on for other combinations).

```

(related to issue #5 and issue #10)
