### PR TITLE
Add class related waiters.

### DIFF
--- a/src/io/aviso/taxi_toolkit/assertions.clj
+++ b/src/io/aviso/taxi_toolkit/assertions.clj
@@ -5,8 +5,7 @@
             [clojure.test :refer [is]]
             [io.aviso.taxi-toolkit
              [ui :refer :all]
-             [utils :refer :all]
-             [waiters :refer :all]]))
+             [utils :refer :all]]))
 
 (defn text=
   "UI assertion for text content. Use either text or regular expression."
@@ -74,40 +73,3 @@
     (let [match-result (doall (map (fn [[element expectation]]
                                      ((f expectation) element)) (zipmap els expected)))]
       (every? true? match-result))))
-
-(defn assert-ui
-  "Accepts a map in a following form:
-   {el-spec1 assertions1
-    el-spec2 assertions2}
-  Each el-spec is an element path from n UI map (or a vector,
-  if element is nested in this map).
-  Each assertion is either one function, or a sequence of thereof,
-  which will be run over an element.
-  Example:
-    (def ui {:some-table {:some-header #(by-xpath \"...\")}
-             :some-div #(...)})
-    (def assert-ui (assert-ui-factory ui))
-
-    (deftest example
-      (assert-ui {[:some-table :some-header] [exists? (text= \"Header\")]
-                   :some-div                 visible?}))
-
-  If the assertion expects a collection of elements, use :all hint:
-    (assert-ui {^:all [:some-element-collection] (count= 3)})"
-  [m]
-  (doseq [[el-spec asserts] m
-            assert-fn (as-vector asserts)]
-    (let [collection? (-> el-spec meta :all)
-          find-fn (if collection? $$ $)
-          el (apply find-fn (as-vector el-spec))]
-      (is (assert-fn el) (str el-spec " assertion failed at " assert-fn)))))
-
-(defn assert-nav
-  "Helper for asserting whether clicking element (or sequence of elements)
-  causes browser window to navigate to a certain URL."
-
-  [& args]
-  (let [ui-actions (butlast args)
-        url (last args)]
-    (apply a-ui ui-actions)
-    (wait-for-url url)))

--- a/src/io/aviso/taxi_toolkit/composite_assertions.clj
+++ b/src/io/aviso/taxi_toolkit/composite_assertions.clj
@@ -1,0 +1,46 @@
+(ns io.aviso.taxi-toolkit.composite-assertions
+  "Complex assertion helpers for UI elements."
+  (:require [clj-webdriver.taxi :as t]
+            [clojure.string :as s]
+            [clojure.test :refer [is]]
+            [io.aviso.taxi-toolkit
+             [ui :refer :all]
+             [utils :refer :all]
+             [waiters :refer :all]]))
+
+(defn assert-ui
+  "Accepts a map in a following form:
+   {el-spec1 assertions1
+    el-spec2 assertions2}
+  Each el-spec is an element path from n UI map (or a vector,
+  if element is nested in this map).
+  Each assertion is either one function, or a sequence of thereof,
+  which will be run over an element.
+  Example:
+    (def ui {:some-table {:some-header #(by-xpath \"...\")}
+             :some-div #(...)})
+    (def assert-ui (assert-ui-factory ui))
+
+    (deftest example
+      (assert-ui {[:some-table :some-header] [exists? (text= \"Header\")]
+                   :some-div                 visible?}))
+
+  If the assertion expects a collection of elements, use :all hint:
+    (assert-ui {^:all [:some-element-collection] (count= 3)})"
+  [m]
+  (doseq [[el-spec asserts] m
+            assert-fn (as-vector asserts)]
+    (let [collection? (-> el-spec meta :all)
+          find-fn (if collection? $$ $)
+          el (apply find-fn (as-vector el-spec))]
+      (is (assert-fn el) (str el-spec " assertion failed at " assert-fn)))))
+
+(defn assert-nav
+  "Helper for asserting whether clicking element (or sequence of elements)
+  causes browser window to navigate to a certain URL."
+
+  [& args]
+  (let [ui-actions (butlast args)
+        url (last args)]
+    (apply a-ui ui-actions)
+    (wait-for-url url)))

--- a/src/io/aviso/taxi_toolkit/index.clj
+++ b/src/io/aviso/taxi_toolkit/index.clj
@@ -3,10 +3,10 @@
   (:require [potemkin :refer [import-vars]]
             [io.aviso.taxi-toolkit
              [assertions ui waiters]]
+            [io.aviso.taxi-toolkit.composite-assertions]
             [io.aviso.taxi-toolkit.selectors.angular]
             [io.aviso.taxi-toolkit.selectors.general]
             [io.aviso.taxi-toolkit.selectors.complex]))
-
 
 (defn ns-public-symbols
   "Returns a sequence of all public synbols from a namespace,
@@ -22,6 +22,7 @@
     `(import-vars ~x)))
 
 (import-ns-vars io.aviso.taxi-toolkit.assertions)
+(import-ns-vars io.aviso.taxi-toolkit.composite-assertions)
 (import-ns-vars io.aviso.taxi-toolkit.ui)
 (import-ns-vars io.aviso.taxi-toolkit.waiters)
 (import-ns-vars io.aviso.taxi-toolkit.selectors.general)

--- a/src/io/aviso/taxi_toolkit/waiters.clj
+++ b/src/io/aviso/taxi_toolkit/waiters.clj
@@ -6,7 +6,8 @@
             [clojure.test :refer [is]]
             [io.aviso.taxi-toolkit
              [ui :refer :all]
-             [utils :refer :all]]))
+             [utils :refer :all]
+             [assertions :as at]]))
 
 (defn wait-for
   "Waits for element to appear in the DOM."
@@ -67,6 +68,22 @@
   "Waits for an element to be removed from the DOM"
   [& el-spec]
   (wait-until #(nil? (apply $ el-spec)) webdriver-timeout))
+
+(defn wait-for-class
+  "Waits for an element to have a certain class"
+  [cls & el-spec]
+  (try
+    (wait-until #((at/has-class? cls) (apply $ el-spec)) webdriver-timeout)
+    (catch org.openqa.selenium.TimeoutException err
+      (is false (str "Waited for class '" cls "' to appear on " el-spec " but it never did.")))))
+
+(defn wait-for-class-removed
+  "Waits for an element to NOT have a certain class"
+  [cls & el-spec]
+  (try
+    (wait-until #((at/has-no-class? cls) (apply $ el-spec)) webdriver-timeout)
+    (catch org.openqa.selenium.TimeoutException err
+      (is false (str "Waited for element " el-spec " to NOT have class '" cls "', but that never happened.")))))
 
 (defn a-hover
   "Hover an item."


### PR DESCRIPTION
Also move composite assertion functions to a separate namespace
removing unnecessary dependencies of the assertion namespace.

closes #15
