### PR TITLE
Refactor assertions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 # CHANGELOG
 
+## 0.2.0
+
+- Improved fail message for some waiters.
+- Only assertion function from taxi-toolkit is accepted by `assert-ui`.
+- Most (if not all) relevant UI checks from taxi now has a corresponding assertion in taxi-toolkit.
+- `assert-ui` no longer asserts by itself, but simply runs assertion functions from taxi-toolkit. This enables possibility for more eloquent, relevant and verbose fail messages.
+- `each` may now be called with either 1 argument or 2 arguments, depending on if the assertion is simple or requires an expected value.
+- Assertions now have a uniform name convension.
+  - ~~`text=`~~ `has-text?`
+  - ~~`attr=`~~ `has-attr?` or `has-attribute?`
+  - ~~`count=`~~ `is-count?` or `found-exact-nr?` `is-exactly-nr?`
+  - ~~`visible?`~~ `is-visible?`
+  - ~~`focused?`~~ `is-focused?`
+  - ~~`missing?`~~ `is-missing?`
+  - ~~`is-missing?`~~ `x-is-missing?` _(express function)_
+  - ~~`selected?`~~ `is-selected?`
+  - ~~`hidden?`~~ `is-hidden?`
+  - ~~`enabled?`~~ `is-enabled?`
+  - ~~`disabled?`~~ `is-disabled?`
+- Added new assertion functions.
+  - `has-value?`
+  - `is-not-focused?`
+  - `is-present?`
+  - `is-existing?`
+  - `is-not-selected?` or `is-deselected?`
+  - `is-displayed?` _alias of `is-visible?`_
+  - `allows-multiple?`
+  - `is-not-multiple?`
+  - `has-page-title?`
+- Revised documentation (readme).
+
 ## 0.1.7
+
 - New waiter function `wait-for-element-count`.
 
 ## 0.1.6

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.aviso/taxi-toolkit "0.1.7-SNAPSHOT"
+(defproject io.aviso/taxi-toolkit "0.2.0"
   :description "A Clojure library designed to help with writing integration tests using clj-webdriver."
   :url "https://github.com/AvisoNovate/taxi-toolkit"
   :license {:name "Apache Sofware License 2.0"

--- a/src/io/aviso/taxi_toolkit/composite_assertions.clj
+++ b/src/io/aviso/taxi_toolkit/composite_assertions.clj
@@ -33,7 +33,7 @@
     (let [collection? (-> el-spec meta :all)
           find-fn (if collection? $$ $)
           el (apply find-fn (as-vector el-spec))]
-      (is (assert-fn el) (str el-spec " assertion failed at " assert-fn)))))
+      (assert-fn el))))
 
 (defn assert-nav
   "Helper for asserting whether clicking element (or sequence of elements)

--- a/src/io/aviso/taxi_toolkit/waiters.clj
+++ b/src/io/aviso/taxi_toolkit/waiters.clj
@@ -1,7 +1,7 @@
 (ns io.aviso.taxi-toolkit.waiters
   "Assertion helpers for UI elements."
   (:require [clj-webdriver.taxi :refer :all]
-				  	[clj-webdriver.core :refer [->actions move-to-element]]
+            [clj-webdriver.core :refer [->actions move-to-element]]
             [clojure.string :as s]
             [clojure.test :refer [is]]
             [io.aviso.taxi-toolkit
@@ -33,7 +33,10 @@
   "Waits for element to be enabled."
   [& el-spec]
   (apply wait-for el-spec)
-  (wait-until #(enabled? (apply $ el-spec)) webdriver-timeout))
+  (try
+    (wait-until #(enabled? (apply $ el-spec)) webdriver-timeout)
+    (catch org.openqa.selenium.TimeoutException err
+      (is false (str "Waited for element " el-spec " to be enabled.")))))
 
 (defn wait-for-url
   "Waits for the browser to load an URL which would match (partially)
@@ -47,7 +50,10 @@
 (defn wait-for-present
   "Waits for an element to be considered present. Existing and visible."
   [& el-spec]
-  (wait-until #(present? (apply $ el-spec)) webdriver-timeout))
+  (try
+    (wait-until #(present? (apply $ el-spec)) webdriver-timeout)
+    (catch org.openqa.selenium.TimeoutException err
+      (is false (str "Waited for element " el-spec " to be present.")))))
 
 (defn wait-for-ng-animations
   "Waits for Angular animations to complete."
@@ -73,7 +79,7 @@
   "Waits for an element to have a certain class"
   [cls & el-spec]
   (try
-    (wait-until #((at/has-class? cls) (apply $ el-spec)) webdriver-timeout)
+    (wait-until #(some #{cls} (classes (apply $ el-spec))) webdriver-timeout)
     (catch org.openqa.selenium.TimeoutException err
       (is false (str "Waited for class '" cls "' to appear on " el-spec " but it never did.")))))
 
@@ -81,7 +87,7 @@
   "Waits for an element to NOT have a certain class"
   [cls & el-spec]
   (try
-    (wait-until #((at/has-no-class? cls) (apply $ el-spec)) webdriver-timeout)
+    (wait-until #(nil? (some #{cls} (classes (apply $ el-spec)))) webdriver-timeout)
     (catch org.openqa.selenium.TimeoutException err
       (is false (str "Waited for element " el-spec " to NOT have class '" cls "', but that never happened.")))))
 


### PR DESCRIPTION
- More consistency throughout assertions
- Each can now be used with more assertions

---
- Improved fail message for some waiters.
- Only assertion function from taxi-toolkit is accepted by `assert-ui`.
- Most (if not all) relevant UI checks from taxi now has a corresponding assertion in taxi-toolkit.
- `assert-ui` no longer asserts by itself, but simply runs assertion functions from taxi-toolkit. This enables possibility for more eloquent, relevant and verbose fail messages.
- `each` may now be called with either 1 argument or 2 arguments, depending on if the assertion is simple or requires an expected value.
- Assertions now have a uniform name convension.
  - ~~`text=`~~ `has-text?`
  - ~~`attr=`~~ `has-attr?` or `has-attribute?`
  - ~~`count=`~~ `is-count?` or `found-exact-nr?` `is-exactly-nr?`
  - ~~`visible?`~~ `is-visible?`
  - ~~`focused?`~~ `is-focused?`
  - ~~`missing?`~~ `is-missing?`
  - ~~`is-missing?`~~ `x-is-missing?` _(express function)_
  - ~~`selected?`~~ `is-selected?`
  - ~~`hidden?`~~ `is-hidden?`
  - ~~`enabled?`~~ `is-enabled?`
  - ~~`disabled?`~~ `is-disabled?`
- Added new assertion functions.
  - `has-value?`
  - `is-not-focused?`
  - `is-present?`
  - `is-existing?`
  - `is-not-selected?` or `is-deselected?`
  - `is-displayed?` _alias of `is-visible?`_
  - `allows-multiple?`
  - `is-not-multiple?`
  - `has-page-title?`
- Revised documentation (readme).
