### PR TITLE
Add js-click that uses JS to perform click action

### DIFF
--- a/src/io/aviso/taxi_toolkit/ui.clj
+++ b/src/io/aviso/taxi_toolkit/ui.clj
@@ -64,6 +64,12 @@
     ("input") (retry #(value el))
     (retry #(text el))))
 
+(defn js-click
+  "Invokes click event on an element using DOM API."
+  [& el-spec]
+  (let [el (apply $ el-spec)]
+    (wd/execute-script *driver* "arguments[0].click();" (:webelement el))))
+
 (defn classes
   "Return list of CSS classes element has applied directly (via attribute)."
   [el]


### PR DESCRIPTION
This was indispensable when clicking on an elements that are appearing when user hovers over parent elements - standard actions resulted in IE driver performing movements that were making parent elements disappearing.
