### PR TITLE
Retry find+assert + some fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,7 @@
   :url "https://github.com/AvisoNovate/taxi-toolkit"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.5.0"]
-                 [potemkin "0.3.12"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [clj-webdriver "0.7.2"]
+                 [potemkin "0.3.12"]]
+  :profiles {:dev {:dependencies [[org.seleniumhq.selenium/selenium-java "2.50.0"]]}})

--- a/src/io/aviso/taxi_toolkit/composite_assertions.clj
+++ b/src/io/aviso/taxi_toolkit/composite_assertions.clj
@@ -2,11 +2,51 @@
   "Complex assertion helpers for UI elements."
   (:require [clj-webdriver.taxi :as t]
             [clojure.string :as s]
-            [clojure.test :refer [is]]
+            [clojure.test :refer [is] :as test]
             [io.aviso.taxi-toolkit
              [ui :refer :all]
              [utils :refer :all]
-             [waiters :refer :all]]))
+             [waiters :refer :all]])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn- retry-find+assert
+  "Finding elements in the DOM and running assertions on them sometimes throws StaleElementExceptions
+  due to rerendering in-between the two steps. Retrying the two steps a couple of times is a
+  reasonable workaround."
+  {:test (fn [] (let [find-fn (constantly nil)
+                      i (atom 3)
+                      assert-fn (fn [_] (if (= 0 @i)
+                                          (is true)
+                                          (do (swap! i dec)
+                                              (is false))))
+                      j (atom 3)
+                      throw-fn (fn [_] (if (= 0 @j)
+                                         (is true)
+                                         (do (swap! j dec)
+                                             (throw (ex-info "assertion has thrown an exception" {})))))]
+                  (is (retry-find+assert find-fn assert-fn))
+                  (is (= 0 @i))
+                  (is (retry-find+assert find-fn throw-fn))
+                  (is (= 0 @j))))}
+  [find-fn assert-fn]
+  (let [result (atom false)
+        test-report test/report
+        spy-report (fn [data]
+                     (case (:type data)
+                       :fail nil
+                       :error nil
+                       :pass (do (reset! result true)
+                                 (test-report data))
+                       (test-report data)))
+        retriable #(let [return (assert-fn (find-fn))]
+                    (when-not @result (throw (ex-info "forcing a retry" {})))
+                    return)
+        return (with-redefs [test/report spy-report]
+                 (try (retry-times retriable)
+                      (catch ExceptionInfo e nil)))]
+    (if @result
+      return
+      (assert-fn (find-fn)))))
 
 (defn assert-ui
   "Accepts a map in a following form:
@@ -29,11 +69,12 @@
     (assert-ui {^:all [:some-element-collection] (count= 3)})"
   [m]
   (doseq [[el-spec asserts] m
-            assert-fn (as-vector asserts)]
+          assert-fn (as-vector asserts)]
     (let [collection? (-> el-spec meta :all)
-          find-fn (if collection? $$ $)
-          el (apply find-fn (as-vector el-spec))]
-      (assert-fn el))))
+          finder (if collection? $$ $)
+          el-spec-vector (as-vector el-spec)
+          find-fn #(apply finder el-spec-vector)]
+      (retry-find+assert find-fn assert-fn))))
 
 (defn assert-nav
   "Helper for asserting whether clicking element (or sequence of elements)

--- a/src/io/aviso/taxi_toolkit/ui.clj
+++ b/src/io/aviso/taxi_toolkit/ui.clj
@@ -1,6 +1,6 @@
 (ns io.aviso.taxi-toolkit.ui
   "Set of helper functions for interacting with DOM elements."
-  (:require [clj-webdriver.taxi :refer :all]
+  (:require [clj-webdriver.taxi :refer :all :as taxi]
             [clj-webdriver.core :refer [->actions move-to-element click-and-hold release]]
             [clojure.string :as s]
             [clojure.test :refer [is]]
@@ -68,7 +68,7 @@
   "Invokes click event on an element using DOM API."
   [& el-spec]
   (let [el (apply $ el-spec)]
-    (wd/execute-script *driver* "arguments[0].click();" (:webelement el))))
+    (taxi/execute-script *driver* "arguments[0].click();" (:webelement el))))
 
 (defn classes
   "Return list of CSS classes element has applied directly (via attribute)."

--- a/src/io/aviso/taxi_toolkit/utils.clj
+++ b/src/io/aviso/taxi_toolkit/utils.clj
@@ -56,7 +56,7 @@ execution takes time to perform."
    (try
      (f)
      (catch Exception e
-       (if (<= times 0)
+       (if (<= times 1)
          (throw e)
          (do
            (Thread/sleep 100)

--- a/src/io/aviso/taxi_toolkit/utils.clj
+++ b/src/io/aviso/taxi_toolkit/utils.clj
@@ -60,4 +60,4 @@ execution takes time to perform."
          (throw e)
          (do
            (Thread/sleep 100)
-           (retry f (dec times))))))))
+           (retry-times f (dec times))))))))

--- a/src/io/aviso/taxi_toolkit/waiters.clj
+++ b/src/io/aviso/taxi_toolkit/waiters.clj
@@ -113,7 +113,7 @@
 (defn wait-for-class-removed
   "Waits for an element to NOT have a certain class"
   [cls & el-spec]
-  (smart-wait #(nil? (some #{cls} (classes (apply $ el-spec)))) el-spec))
+  (smart-wait #(nil? (some #{cls} (classes %))) el-spec))
 
 (defn wait-for-element-count
   "Waits for the number of elements to be found by a selector to match expected number."


### PR DESCRIPTION
Asserts behave as waiters to some level, to deal with possible DOM re-rendering in between finding the element and asserting on it. Some other minor fixes.
