### PR TITLE
Retrying for actions + fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.2.4
+
+- Changed the behaviour of actions to use the same retrying mechanism as `assert-ui`. This should make the testing more deterministic against libraries that re-render the UI often.
+- Unified the API to avoid using element references, this changed `a-text` and `classes` signatures. Those functions also employ retrying mechanism so they are meant to be used
+  for test logic, not for assertions (assertions work on element references as they are to be used from within `assert-ui`).
+  
+## 0.2.3
+
+- Changed the behaviour of `assert-ui` to retry on exception to avoid having explicitly wait for element before asserting and to avoid various exceptions caused by stale references.
 
 ## 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Works like `taxi/click` for elements such as `<a>` or `<button>`, and like
 
 #### a-text
 
-`(a-text ($ :menu :log-out))`
+`(a-text :menu :log-out)`
 
 Works like `taxi/text` for elements such as `<div>` or `<p>`, and like
 `taxi/value` for form elements like `<input>`.
@@ -647,7 +647,7 @@ Works like `taxi/text` for elements such as `<div>` or `<p>`, and like
 
 #### click-non-clickable
 
-`(click-non-clickable ($ :menu :log-out))`
+`(click-non-clickable :menu :log-out)`
 
 Clicks elements that are not anchors or buttons. Works by moving the cursor
 on top of that element, then pressing and releasing a mouse button.

--- a/src/io/aviso/taxi_toolkit/assertions.clj
+++ b/src/io/aviso/taxi_toolkit/assertions.clj
@@ -11,7 +11,7 @@
   "UI assertion for text content. Use either text or regular expression."
   [txt]
   (fn [el]
-    (let [actual-txt (s/trim (a-text el))]
+    (let [actual-txt (s/trim (el-text el))]
       (is ((str-eq txt) actual-txt) (format "Expected <<%s>> Actual <<%s>>." txt actual-txt)))))
 
 (defn has-attr?
@@ -63,13 +63,13 @@
   "UI assertion for a CSS class to exist on a certain element."
   [css-class]
   (fn [el]
-    (is (not (nil? (some #{css-class} (classes el)))) (str "Expected element to have the class '" css-class "' but it didn't.  It had: " (classes el) "."))))
+    (is (not (nil? (some #{css-class} (el-classes el)))) (str "Expected element to have the class '" css-class "' but it didn't.  It had: " (el-classes el) "."))))
 
 (defn has-no-class?
   "UI assertion for a CSS class to NOT exist on a certain element."
   [css-class]
   (fn [el]
-    (is (nil? (some #{css-class} (classes el))) (str "Expected element to NOT have the class '" css-class "' but it did. It had: " (classes el) "."))))
+    (is (nil? (some #{css-class} (el-classes el))) (str "Expected element to NOT have the class '" css-class "' but it did. It had: " (el-classes el) "."))))
 
 (defn is-selected?
   "UI assertion for an <option> element to be selected."

--- a/src/io/aviso/taxi_toolkit/ui.clj
+++ b/src/io/aviso/taxi_toolkit/ui.clj
@@ -12,6 +12,10 @@
 (def webdriver-timeout (* 15 1000))
 (def ^:private ui-maps (atom {}))
 
+(defmacro retrying
+  "Just a convenience macro."
+  [& body]
+  `(retry-till-timeout webdriver-timeout (fn [] ~@body)))
 
 (defn set-ui-spec!
   [& xs]
@@ -51,24 +55,30 @@
 (defn a-click
   "Element-agnostic. Runs either (taxi/click) or (click-anything)."
   [& el-spec]
-  (let [el (apply $ el-spec)]
-    (case (.getTagName (:webelement el))
-      ("a" "button") (retry #(click el))
-      (retry #(click-non-clickable el)))))
+  (retrying
+   (let [el (apply $ el-spec)]
+     (case (.getTagName (:webelement el))
+       ("a" "button") (click el)
+       (click-non-clickable el)))))
 
 (defn a-text
   "For non-form elements such as <div> works like (taxi/text).
   For <input> works like (taxi/value)."
   [el]
-  (case (.getTagName (:webelement el))
-    ("input") (retry #(value el))
-    (retry #(text el))))
+  ;; TODO: this one is sometimes used as a checker in smart-wait/wait-until
+  ;; and sometimes as a standalone operation. The retrying here is not needed
+  ;; in case of smart-wait
+  (retrying
+   (case (.getTagName (:webelement el))
+     ("input") (value el)
+     (text el))))
 
 (defn js-click
   "Invokes click event on an element using DOM API."
   [& el-spec]
-  (let [el (apply $ el-spec)]
-    (taxi/execute-script *driver* "arguments[0].click();" (:webelement el))))
+  (retrying
+   (let [el (apply $ el-spec)]
+     (taxi/execute-script *driver* "arguments[0].click();" (:webelement el)))))
 
 (defn classes
   "Return list of CSS classes element has applied directly (via attribute)."
@@ -91,29 +101,34 @@
   [& el-val-or-entries]
   (let [el-val (if (= (count el-val-or-entries) 1)
                  (first el-val-or-entries)
-                 (partition 2 el-val-or-entries))]
+                 (partition 2 el-val-or-entries))
+        start (System/currentTimeMillis)]
     (doseq [[el-spec value] el-val]
-      (let [q-getter #(apply $ (as-vector el-spec))]
-        (wait-until #(let [q (q-getter)]
-                      (and q
-                           (enabled? q)
-                           (visible? q)))
-                    webdriver-timeout)
-        (let [q (q-getter)
-              tag-name (s/lower-case (tag q))
-              type-attr (s/lower-case (or (attribute q "type") ""))]
-          (case tag-name
-            "select" (retry-times #(select-option q value) 5)
-            ("textarea" "input") (case type-attr
-                                   ("radio" "checkbox") (retry-times #(if value (select q) (deselect q)) 5)
-                                   (retry-times #(do
-                                                  (clear q)
-                                                  (input-text q value)))))))))
+      (retry-till-timeout webdriver-timeout
+       (fn []
+         (let [q-getter #(apply $ (as-vector el-spec))]
+           (wait-until #(let [q (q-getter)]
+                          (and q
+                               (enabled? q)
+                               (visible? q)))
+                       webdriver-timeout)
+           (let [q (q-getter)
+                 tag-name (s/lower-case (tag q))
+                 type-attr (s/lower-case (or (attribute q "type") ""))]
+             (case tag-name
+               "select" (select-option q value)
+               ("textarea" "input") (case type-attr
+                                      ("radio" "checkbox") (if value (select q) (deselect q))
+                                      (do
+                                        (clear q)
+                                        (input-text q value)))))))
+       :start start)))
   el-val-or-entries)
 
 (defn clear-with-backspace
   "Clears the input by pressing the backspace key until it's empty."
   [& el-spec]
-  (let [el (apply $ el-spec)
-        n-of-strokes (count (a-text el))]
-    (doall (repeatedly n-of-strokes #(send-keys el org.openqa.selenium.Keys/BACK_SPACE)))))
+  (retrying
+   (let [el (apply $ el-spec)
+         n-of-strokes (count (a-text el))]
+     (doall (repeatedly n-of-strokes #(send-keys el org.openqa.selenium.Keys/BACK_SPACE))))))

--- a/src/io/aviso/taxi_toolkit/utils.clj
+++ b/src/io/aviso/taxi_toolkit/utils.clj
@@ -1,5 +1,7 @@
 (ns io.aviso.taxi-toolkit.utils
-  (:require [clojure.string :as s])
+  (:require [clojure.string :as s]
+            [clj-webdriver.core :refer [->actions move-to-element click-and-hold release]]
+            [clj-webdriver.taxi :as taxi])
   (:import [org.openqa.selenium TimeoutException]))
 
 (defn str-eq
@@ -67,3 +69,25 @@
         :else (do
                 (Thread/sleep 17)
                 (recur (wrapped)))))))
+
+(defn el-text
+  "For non-form elements such as <div> works like (taxi/text).
+  For <input> works like (taxi/value)."
+  [el]
+  (case (.getTagName (:webelement el))
+    ("input") (taxi/value el)
+    (taxi/text el)))
+
+(defn el-classes
+  "Splits the class attribute to obtain list of element classes."
+  [el]
+  (s/split (taxi/attribute el :class) #"\s+"))
+
+(defn el-click-non-clickable
+  "Similar to (taxi/click), but works with non-clickable elements such as <div>
+   or <li>."
+  [el]
+  (->actions taxi/*driver*
+             (move-to-element el)
+             (click-and-hold el)
+             (release el)))

--- a/src/io/aviso/taxi_toolkit/waiters.clj
+++ b/src/io/aviso/taxi_toolkit/waiters.clj
@@ -15,7 +15,7 @@
   Useful when tests use common functions in different scenarios, adhering to DRY principle."
   [checker el-spec]
   (try
-    (wait-until #(retry-times (fn [] (checker (apply $ el-spec)))) webdriver-timeout)
+    (retry-till-timeout webdriver-timeout #() :pred #(checker (apply $ el-spec)))
     (catch org.openqa.selenium.TimeoutException e
       (throw (org.openqa.selenium.TimeoutException. (str "Timeout exceeded for: " checker " with el spec: " el-spec) e)))))
 
@@ -95,9 +95,9 @@
   (Thread/sleep 500))
 
 (defn wait-and-click
-  "Waits for an element to appear, and then clicks it."
+  "Waits for an element to be enabled, and then clicks it."
   [& el-spec]
-  (apply wait-for el-spec)
+  (smart-wait enabled? el-spec)
   (apply a-click el-spec))
 
 (defn wait-for-removed

--- a/src/io/aviso/taxi_toolkit/waiters.clj
+++ b/src/io/aviso/taxi_toolkit/waiters.clj
@@ -108,12 +108,12 @@
 (defn wait-for-class
   "Waits for an element to have a certain class"
   [cls & el-spec]
-  (smart-wait #(some #{cls} (classes %)) el-spec))
+  (smart-wait #(some #{cls} (el-classes %)) el-spec))
 
 (defn wait-for-class-removed
   "Waits for an element to NOT have a certain class"
   [cls & el-spec]
-  (smart-wait #(nil? (some #{cls} (classes %))) el-spec))
+  (smart-wait #(nil? (some #{cls} (el-classes %))) el-spec))
 
 (defn wait-for-element-count
   "Waits for the number of elements to be found by a selector to match expected number."


### PR DESCRIPTION
- Uses same mechanics as retrying assertions
- Favours retrying whole action than just parts of it, as it may
  protects from StaleElementReference exceptions as well
- Fix for wait-and-click that waits for element to be enabled
- Unified retrying mechanics for smart-wait and other retries
- Fix assert-ui to use thread-local binding and timeout per assert-ui
