### PR TITLE
Fix f-nested for missing elements and add try- actions

### DIFF
--- a/src/io/aviso/taxi_toolkit/ui_map.clj
+++ b/src/io/aviso/taxi_toolkit/ui_map.clj
@@ -42,8 +42,8 @@
       (if (or (= nil child-spec)
               (= :self child-spec))
         (f-one (resolve-element-path ui el-spec))
-        (f-nested (find-element (resolve-element-path ui parent-spec))
-                  (resolve-element-path ui el-spec))))))
+        (if-let [parent (find-element (resolve-element-path ui parent-spec))]
+          (f-nested parent (resolve-element-path ui el-spec)))))))
 
 (defn find-one
   "Find one element matching selector. See (find-with-f)."

--- a/src/io/aviso/taxi_toolkit/utils.clj
+++ b/src/io/aviso/taxi_toolkit/utils.clj
@@ -57,7 +57,7 @@
   [timeout f & {:keys [pred start]
                 :or {pred (constantly true)
                      start (System/currentTimeMillis)}}]
-  (let [wrapped #(try [::success (f) (pred)] (catch Exception e [::error e false]))]
+  (let [wrapped #(try [::success (f) (pred)] (catch Throwable e [::error e false]))]
     (loop [[tag ret check] (wrapped)]
       (cond
         (and (= tag ::success) check)


### PR DESCRIPTION
Previously, f-nested, in case when parent was missing, was producing this awful "need to specify :css or xpath whatever" message, it's now returning nil (so the behaviour is the same as for "single" el-spec.

Also, added try-click (and some other counterparts) that are not failing when element is missing. (Useful when one wants to click "dismiss" button and the element can disappear in the meantime).